### PR TITLE
Potential fix for code scanning alert no. 3: Clear text transmission of sensitive cookie

### DIFF
--- a/node/server.js
+++ b/node/server.js
@@ -41,7 +41,7 @@ app.use(session({
     saveUninitialized: false,
     cookie: {
         httpOnly: true,
-        secure: false
+        secure: true
     }
 }));
 app.use(lusca.csrf());


### PR DESCRIPTION
Potential fix for [https://github.com/gaon12/eureka/security/code-scanning/3](https://github.com/gaon12/eureka/security/code-scanning/3)

To fix the problem, we need to ensure that the session cookies are only transmitted over secure (HTTPS) connections. This can be achieved by setting the `secure` attribute of the session cookie to `true`. This change should be made in the session configuration object within the `node/server.js` file.

1. Locate the session configuration object in the `node/server.js` file.
2. Set the `secure` attribute of the `cookie` object to `true`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
