### PR TITLE
Potential fix for code scanning alert no. 32: Missing rate limiting

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -19,7 +19,8 @@
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4",
-    "lusca": "^1.7.0"
+    "lusca": "^1.7.0",
+    "express-rate-limit": "^7.5.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/node/route/userRouter.js
+++ b/node/route/userRouter.js
@@ -5,9 +5,15 @@ const bcrypt = require('bcrypt');
 const { isAdmin } = require('../middleware/isAdmin');
 const { isSignin } = require('../middleware/isSignin');
 const { isSignout } = require('../middleware/isSignout');
+const rateLimit = require('express-rate-limit');
+
+const limiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // max 100 requests per windowMs
+});
 
 /** /POST, 관리자 여부 판단 메서드 */
-router.post('/isAdmin', async (req, res) => {
+router.post('/isAdmin', limiter, async (req, res) => {
     try {
         const dong = req.body.dong;
         const ho = req.body.ho;
@@ -39,7 +45,7 @@ router.post('/isAdmin', async (req, res) => {
 })
 
 /** /GET, 유저 정보 조회 메서드 */
-router.get('/info', isAdmin, async (req, res, next) => {
+router.get('/info', isAdmin, limiter, async (req, res, next) => {
     try {
         const [users] = await db.query('SELECT dong, ho, username, movein, phone1, phone2 FROM user WHERE isAdmin != 1');
 
@@ -103,7 +109,7 @@ router.get('/signout', isSignin, async (req, res, next) => {
 /** /POST, 로그인 메서드
  *  JSON 형식으로 http 상태코드, 메시지 반환
  */
-router.post('/signin', isSignout, async (req, res, next) => {
+router.post('/signin', isSignout, limiter, async (req, res, next) => {
     const dong = req.body.dong;
     const ho = req.body.ho;
     const pw = req.body.pw;
@@ -187,7 +193,7 @@ router.post('/signin', isSignout, async (req, res, next) => {
  *  phone2 항목이 빈칸이면 NULL로 채움
  *  JSON 형식으로 http 상태 코드, 메시지 반환
  */
-router.post('/signup', isSignout, async (req, res, next) => {
+router.post('/signup', isSignout, limiter, async (req, res, next) => {
     const dong = req.body.dong;
     const ho = req.body.ho;
     const username = req.body.username;


### PR DESCRIPTION
Potential fix for [https://github.com/gaon12/eureka/security/code-scanning/32](https://github.com/gaon12/eureka/security/code-scanning/32)

To fix the problem, we need to introduce rate limiting to the route handlers that perform database access. The best way to achieve this is by using the `express-rate-limit` middleware, which allows us to set a maximum number of requests that can be made within a specified time window. This will help prevent denial-of-service attacks by limiting the rate at which requests are accepted.

We will:
1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `node/route/userRouter.js` file.
3. Set up a rate limiter with appropriate configuration.
4. Apply the rate limiter to the specific routes that perform database access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
